### PR TITLE
feat: Refactor beacon blocks/state storage

### DIFF
--- a/.github/actions/checkpoint-sync/action.yaml
+++ b/.github/actions/checkpoint-sync/action.yaml
@@ -95,7 +95,7 @@ runs:
       if:  ${{ inputs.consensus == 'prysm' }}
       run: |
         echo "Starting prysm...";
-        docker run -d --name beacon --network eth -p 5052:5052 gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --accept-terms-of-use --${{ inputs.network }} --clear-db --grpc-gateway-port=5052 --grpc-gateway-host=0.0.0.0 --http-web3provider=http://localhost:8545 --force-clear-db --checkpoint-sync-url=http://checkpointz:5555 --genesis-beacon-api-url=http://checkpointz:5555 --grpc-gateway-port=5052
+        docker run -d --name beacon --network eth -p 5052:5052 gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --accept-terms-of-use --${{ inputs.network }} --clear-db --grpc-gateway-port=5052 --grpc-gateway-host=0.0.0.0 --execution-endpoint=http://localhost:8545 --force-clear-db --checkpoint-sync-url=http://checkpointz:5555 --genesis-beacon-api-url=http://checkpointz:5555 --grpc-gateway-port=5052
         echo "Prysm is running.";
     - name: Run nimbus
       shell: bash

--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -315,12 +315,12 @@ func (d *Default) fetchBundle(ctx context.Context, root phase0.Root, upstream *N
 			return nil, errors.New("beacon state is nil")
 		}
 
-		expiresAt := time.Now().Add(3 * time.Hour)
+		expiresAt := time.Now().Add(FinalityHaltedServingPeriod)
 		if slot == phase0.Slot(0) {
 			expiresAt = time.Now().Add(999999 * time.Hour)
 		}
 
-		if err := d.states.Add(stateRoot, &beaconState, expiresAt); err != nil {
+		if err := d.states.Add(stateRoot, &beaconState, expiresAt, slot); err != nil {
 			return nil, fmt.Errorf("failed to store beacon state: %w", err)
 		}
 	}

--- a/pkg/beacon/store/block.go
+++ b/pkg/beacon/store/block.go
@@ -65,7 +65,13 @@ func (c *Block) Add(block *spec.VersionedSignedBeaconBlock, expiresAt time.Time)
 		return err
 	}
 
-	c.store.Add(eth.RootAsString(root), block, expiresAt)
+	invincible := false
+	if slot == 0 {
+		// Store the genesis block forever.
+		invincible = true
+	}
+
+	c.store.Add(eth.RootAsString(root), block, expiresAt, invincible)
 
 	c.slotToBlockRoot.Store(slot, root)
 	c.stateRootToBlockRoot.Store(stateRoot, root)

--- a/pkg/beacon/store/deposit_snapshot.go
+++ b/pkg/beacon/store/deposit_snapshot.go
@@ -32,7 +32,7 @@ func NewDepositSnapshot(log logrus.FieldLogger, config Config, namespace string)
 }
 
 func (d *DepositSnapshot) Add(epoch phase0.Epoch, snapshot *types.DepositSnapshot, expiresAt time.Time) error {
-	d.store.Add(eth.EpochAsString(epoch), snapshot, expiresAt)
+	d.store.Add(eth.EpochAsString(epoch), snapshot, expiresAt, false)
 
 	d.log.WithFields(
 		logrus.Fields{

--- a/pkg/beacon/store/state.go
+++ b/pkg/beacon/store/state.go
@@ -30,8 +30,14 @@ func NewBeaconState(log logrus.FieldLogger, config Config, namespace string) *Be
 	return c
 }
 
-func (c *BeaconState) Add(stateRoot phase0.Root, state *[]byte, expiresAt time.Time) error {
-	c.store.Add(eth.RootAsString(stateRoot), state, expiresAt)
+func (c *BeaconState) Add(stateRoot phase0.Root, state *[]byte, expiresAt time.Time, slot phase0.Slot) error {
+	invincible := false
+	if slot == 0 {
+		invincible = true
+	}
+
+	c.store.Add(eth.RootAsString(stateRoot), state, expiresAt, invincible)
+
 	c.log.WithFields(
 		logrus.Fields{
 			"state_root": eth.RootAsString(stateRoot),


### PR DESCRIPTION
This change simplifies the way we store beacon blocks/states (aka "bundles".) This lets us serve the latest finalized epoch for longer (2 weeks), leaning on the cache to clear out old bundles for us. 

This allows us to continue serving bundles in the case where finality is halted for much longer:
Previously: 3 hours of serving the latest finality bundle
With this change: 2 weeks of serving the latest finaly bundle

In the case of a non-finality event greater than 2 weeks, Checkpointz can be restarted to start the 2 week clock again.

While it's tempting to store these bundles forever, doing so would potentially serve a state to a client that falls outside of the weak subjectivity period. While we can calculate that on the fly, that's a larger piece of work that needs to be done. 2 weeks feels like a good middle ground to buy us some time to make that change.
