### PR TITLE
feat: Update beacon to v0.25.0 and add headers to config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,7 +22,6 @@ linters:
   enable:
     - bodyclose
     - deadcode
-    - depguard
     - dogsled
     - dupl
     - errcheck

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -27,3 +27,5 @@ beacon:
     address: http://localhost:5052
     timeoutSeconds: 30
     dataProvider: true
+    # headers:
+    #  header_name: header_value

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/attestantio/go-eth2-client v0.15.7
 	github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9
 	github.com/creasty/defaults v1.6.0
-	github.com/ethpandaops/beacon v0.24.0
+	github.com/ethpandaops/beacon v0.25.0
 	github.com/go-co-op/gocron v1.18.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ethpandaops/beacon v0.24.0 h1:WP0ySKmHgyJWTsVn47zOVEPzZ22FSa/fdkr/iIMmeLM=
-github.com/ethpandaops/beacon v0.24.0/go.mod h1:p+PMyAYXro2hgNEMNbCtzLOvzHund9Q9BTPATvf8/SA=
+github.com/ethpandaops/beacon v0.25.0 h1:pGEZyz/mW8L8vcIxcEEFcLL6ky36ONKJjp73rljC4t8=
+github.com/ethpandaops/beacon v0.25.0/go.mod h1:p+PMyAYXro2hgNEMNbCtzLOvzHund9Q9BTPATvf8/SA=
 github.com/ethpandaops/ethwallclock v0.2.0 h1:EeFKtZ7v6TAdn/oAh0xaPujD7N4amjBxrWIByraUfLM=
 github.com/ethpandaops/ethwallclock v0.2.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
@@ -273,7 +273,6 @@ github.com/samcm/go-eth2-client v0.15.8/go.mod h1:PLRKnILnr63V3yl2VagBqnhVRFBWc0
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sirupsen/logrus v1.9.1 h1:Ou41VVR3nMWWmTiEUnj0OlsgOSCUFgsPAOl6jRIcVtQ=
 github.com/sirupsen/logrus v1.9.1/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/pkg/beacon/node/config.go
+++ b/pkg/beacon/node/config.go
@@ -1,7 +1,8 @@
 package node
 
 type Config struct {
-	Name         string `yaml:"name"`
-	Address      string `yaml:"address"`
-	DataProvider bool   `yaml:"dataProvider"`
+	Name         string            `yaml:"name"`
+	Address      string            `yaml:"address"`
+	DataProvider bool              `yaml:"dataProvider"`
+	Headers      map[string]string `yaml:"headers"`
 }

--- a/pkg/beacon/nodes.go
+++ b/pkg/beacon/nodes.go
@@ -24,8 +24,9 @@ func NewNodesFromConfig(log logrus.FieldLogger, configs []node.Config, namespace
 
 	for i, config := range configs {
 		sconfig := &sbeacon.Config{
-			Name: config.Name,
-			Addr: config.Address,
+			Name:    config.Name,
+			Addr:    config.Address,
+			Headers: config.Headers,
 		}
 
 		opts := *sbeacon.DefaultOptions()


### PR DESCRIPTION
This change allows users to provide headers when connecting to upstream beacon nodes 