### PR TITLE
add `ca-certificates` package to `debian` image

### DIFF
--- a/goreleaser-debian.Dockerfile
+++ b/goreleaser-debian.Dockerfile
@@ -1,3 +1,6 @@
 FROM debian:latest
+RUN apt update; \
+    apt install -y ca-certificates; \
+    rm -rf /var/lib/apt/lists/*
 COPY checkpointz* /checkpointz
 ENTRYPOINT ["/checkpointz"]


### PR DESCRIPTION
allows us to: 
- use a Let's Encrypt certificate on the BN
- manage the system's CA trust to add self-signed CA's 