### PR TITLE
feat: Check for finality every 3m

### DIFF
--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -126,6 +126,16 @@ func (d *Default) startCrons(ctx context.Context) error {
 		return err
 	}
 
+	if _, err := s.Every("3m").Do(func() {
+		for _, node := range d.nodes.Healthy(ctx) {
+			if _, err := node.Beacon.FetchFinality(ctx, "head"); err != nil {
+				d.log.WithError(err).Error("Failed to fetch finality when polling")
+			}
+		}
+	}); err != nil {
+		return err
+	}
+
 	go func() {
 		if err := d.startGenesisLoop(ctx); err != nil {
 			d.log.WithError(err).Fatal("Failed to start genesis loop")


### PR DESCRIPTION
This was removed at the start of the year from the `ethpandaops/beacon` package, so we're re-adding it here in checkpointz to hopefully fix the case where an epoch transition takes a little longer