### PR TITLE
fix: teku checkpoint sync url

### DIFF
--- a/web/src/parts/get-started/GetStarted.tsx
+++ b/web/src/parts/get-started/GetStarted.tsx
@@ -20,7 +20,7 @@ export default function GetStarted() {
     const defaultPublicURL = `${window.location.origin}${
       window.location.pathname === '/' ? '' : window.location.pathname
     }`;
-    return `${data?.data?.public_url ?? defaultPublicURL}${client?.endpointPathSuffix ?? ''}`;
+    return `${data?.data?.public_url ?? defaultPublicURL}`;
   }, [data, client]);
   const lightModeWarning = useMemo(() => {
     if (data?.data?.operating_mode !== 'light') return;

--- a/web/src/parts/get-started/GetStartedSelection.tsx
+++ b/web/src/parts/get-started/GetStartedSelection.tsx
@@ -15,7 +15,6 @@ export type ConsensusClient = {
   image?: string;
   imageClassName?: string;
   description: string;
-  endpointPathSuffix?: string;
   commandLine?: (publicURL: string) => JSX.Element;
   logCheck?: (publicURL: string) => JSX.Element;
   defaultPort?: number;
@@ -165,11 +164,10 @@ level=info msg="BeaconState htr=0x854ca984298e6a0d9fc098b4e37f1b28727e545a8e4d31
     image: TekuImage,
     imageClassName: 'bg-[#ff6e42] p-1',
     description: 'Teku is a Java-based Ethereum 2.0 client developed by ConsenSys.',
-    endpointPathSuffix: '/eth/v2/debug/beacon/states/finalized',
     defaultPort: 5051,
     commandLine: (publicURL: string) => (
       <div className="bg-gray-100 rounded-lg grid">
-        <pre className="overflow-x-auto p-5">--initial-state={publicURL}</pre>
+        <pre className="overflow-x-auto p-5">--checkpoint-sync-url={publicURL}</pre>
       </div>
     ),
     logCheck: (publicURL: string) => (


### PR DESCRIPTION
Teku now takes in a new flag: https://docs.teku.consensys.io/get-started/checkpoint-start