### PR TITLE
fix: Refresh spec on epoch change

### DIFF
--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -599,7 +600,21 @@ func (h *Handler) handleEthV1BeaconBlobSidecars(ctx context.Context, r *http.Req
 		return NewBadRequestResponse(nil), err
 	}
 
-	sidecars, err := h.eth.BlobSidecars(ctx, id)
+	queryParams := r.URL.Query()
+	indicesRaw := queryParams["indices"]
+
+	indices := make([]int, 0, len(indicesRaw))
+
+	for _, index := range indicesRaw {
+		converted, errr := strconv.Atoi(index)
+		if errr != nil {
+			return NewBadRequestResponse(nil), errr
+		}
+
+		indices = append(indices, converted)
+	}
+
+	sidecars, err := h.eth.BlobSidecars(ctx, id, indices)
 	if err != nil {
 		return NewInternalServerErrorResponse(nil), err
 	}

--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -727,7 +727,7 @@ func (d *Default) UpstreamsStatus(ctx context.Context) (map[string]*UpstreamStat
 func (d *Default) ListFinalizedSlots(ctx context.Context) ([]phase0.Slot, error) {
 	slots := []phase0.Slot{}
 
-	spec, err := d.Spec()
+	sp, err := d.Spec()
 	if err != nil {
 		return slots, errors.New("no beacon chain spec available")
 	}
@@ -741,9 +741,9 @@ func (d *Default) ListFinalizedSlots(ctx context.Context) ([]phase0.Slot, error)
 		return slots, errors.New("no finalized checkpoint available")
 	}
 
-	latestSlot := phase0.Slot(uint64(finality.Finalized.Epoch) * uint64(spec.SlotsPerEpoch))
+	latestSlot := phase0.Slot(uint64(finality.Finalized.Epoch) * uint64(sp.SlotsPerEpoch))
 
-	for i, val := uint64(latestSlot), uint64(latestSlot)-uint64(spec.SlotsPerEpoch)*uint64(d.config.HistoricalEpochCount); i > val; i -= uint64(spec.SlotsPerEpoch) {
+	for i, val := uint64(latestSlot), uint64(latestSlot)-uint64(sp.SlotsPerEpoch)*uint64(d.config.HistoricalEpochCount); i > val; i -= uint64(sp.SlotsPerEpoch) {
 		slots = append(slots, phase0.Slot(i))
 	}
 

--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -23,6 +23,8 @@ func (d *Default) downloadServingCheckpoint(ctx context.Context, checkpoint *v1.
 		return errors.New("finalized checkpoint is nil")
 	}
 
+	d.log.WithField("epoch", checkpoint.Finalized.Epoch).Info("Downloading serving checkpoint")
+
 	upstream, err := d.nodes.
 		Ready(ctx).
 		DataProviders(ctx).
@@ -44,10 +46,12 @@ func (d *Default) downloadServingCheckpoint(ctx context.Context, checkpoint *v1.
 		return fmt.Errorf("failed to get slot from block: %w", err)
 	}
 
-	// For simplicity we'll hardcode SLOTS_PER_EPOCH to 32.
-	// TODO(sam.calder-mason): Fetch this from a beacon node and store it in the instance.
-	const slotsPerEpoch = 32
-	if blockSlot%slotsPerEpoch != 0 {
+	sp, err := d.Spec()
+	if err != nil {
+		return fmt.Errorf("failed to fetch spec: %w", err)
+	}
+
+	if blockSlot%sp.SlotsPerEpoch != 0 {
 		return fmt.Errorf("block slot is not aligned from an epoch boundary: %d", blockSlot)
 	}
 
@@ -129,8 +133,9 @@ func (d *Default) fetchHistoricalCheckpoints(ctx context.Context, checkpoint *v1
 	d.historicalMutex.Lock()
 	defer d.historicalMutex.Unlock()
 
-	if d.spec == nil {
-		return errors.New("beacon spec unavailable")
+	spec, err := d.Spec()
+	if err != nil {
+		return errors.New("chain spec unavailable")
 	}
 
 	if d.genesis == nil {
@@ -147,7 +152,7 @@ func (d *Default) fetchHistoricalCheckpoints(ctx context.Context, checkpoint *v1
 		return errors.New("no data provider node available")
 	}
 
-	sp := d.spec
+	sp := spec
 
 	slotsInScope := make(map[phase0.Slot]struct{})
 
@@ -218,7 +223,8 @@ func (d *Default) downloadBlock(ctx context.Context, slot phase0.Slot, upstream 
 	}
 
 	// Same thing with the chain spec.
-	if d.spec == nil {
+	_, err := d.Spec()
+	if err != nil {
 		return nil, errors.New("chain spec not known")
 	}
 
@@ -326,9 +332,9 @@ func (d *Default) fetchBundle(ctx context.Context, root phase0.Root, upstream *N
 		}
 	}
 
-	sp, err := upstream.Beacon.Spec()
+	sp, err := d.Spec()
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch spec from upstream node: %w", err)
+		return nil, fmt.Errorf("failed to fetch spec: %w", err)
 	}
 
 	denebFork, err := sp.ForkEpochs.GetByName("DENEB")
@@ -341,7 +347,7 @@ func (d *Default) fetchBundle(ctx context.Context, root phase0.Root, upstream *N
 		}
 	}
 
-	d.log.Infof("Successfully fetched bundle from %s", upstream.Config.Name)
+	d.log.WithField("root", eth.RootAsString(root)).Infof("Successfully fetched bundle from %s", upstream.Config.Name)
 
 	return block, nil
 }

--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -133,7 +133,7 @@ func (d *Default) fetchHistoricalCheckpoints(ctx context.Context, checkpoint *v1
 	d.historicalMutex.Lock()
 	defer d.historicalMutex.Unlock()
 
-	spec, err := d.Spec()
+	sp, err := d.Spec()
 	if err != nil {
 		return errors.New("chain spec unavailable")
 	}
@@ -151,8 +151,6 @@ func (d *Default) fetchHistoricalCheckpoints(ctx context.Context, checkpoint *v1
 	if err != nil {
 		return errors.New("no data provider node available")
 	}
-
-	sp := spec
 
 	slotsInScope := make(map[phase0.Slot]struct{})
 

--- a/pkg/beacon/finality_provider.go
+++ b/pkg/beacon/finality_provider.go
@@ -33,7 +33,7 @@ type FinalityProvider interface {
 	// Genesis returns the chain genesis.
 	Genesis(ctx context.Context) (*v1.Genesis, error)
 	// Spec returns the chain spec.
-	Spec(ctx context.Context) (*state.Spec, error)
+	Spec() (*state.Spec, error)
 	// UpstreamsStatus returns the status of all the upstreams.
 	UpstreamsStatus(ctx context.Context) (map[string]*UpstreamStatus, error)
 	// GetBlockBySlot returns the block at the given slot.

--- a/pkg/service/eth/eth.go
+++ b/pkg/service/eth/eth.go
@@ -456,6 +456,7 @@ func (h *Handler) BlobSidecars(ctx context.Context, blockID BlockIdentifier, ind
 
 	switch blockID.Type() {
 	case BlockIDGenesis:
+		//nolint:govet // False positive
 		block, err := h.provider.GetBlockBySlot(ctx, phase0.Slot(0))
 		if err != nil {
 			return nil, err
@@ -472,6 +473,7 @@ func (h *Handler) BlobSidecars(ctx context.Context, blockID BlockIdentifier, ind
 
 		slot = sl
 	case BlockIDSlot:
+		//nolint:govet // False positive
 		sslot, err := NewSlotFromString(blockID.Value())
 		if err != nil {
 			return nil, err
@@ -493,6 +495,7 @@ func (h *Handler) BlobSidecars(ctx context.Context, blockID BlockIdentifier, ind
 
 		slot = sl
 	case BlockIDRoot:
+		//nolint:govet // False positive
 		root, err := blockID.AsRoot()
 		if err != nil {
 			return nil, err
@@ -514,6 +517,7 @@ func (h *Handler) BlobSidecars(ctx context.Context, blockID BlockIdentifier, ind
 
 		slot = sl
 	case BlockIDFinalized:
+		//nolint:govet // False positive
 		finality, err := h.provider.Finalized(ctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
- Refreshes the spec every epoch to handle a case where `X_FORK_EPOCH` is changed in upstream beacon nodes
- Fixed a panic that could occur if someone requested the `deposit_snapshot` before the finalized checkpoint was determined
- Added support for the `indices` parameter on the blob_sidecar route
- Improved bootup speed by fetching spec/genesis data immediately after establishing that we have at least 1 healthy upstream node.