### PR TITLE
feat: Parse Beacon State

### DIFF
--- a/.github/actions/checkpoint-sync/action.yaml
+++ b/.github/actions/checkpoint-sync/action.yaml
@@ -93,7 +93,7 @@ runs:
         check_endpoint() {
           local path=$1
           local accept_header=$2
-          local response=$(curl -s -w "\n%{http_code}" -H "accept: ${accept_header}" "localhost:5555${path}")
+          local response=$(curl -s -w "\n%{http_code}" -H "accept: ${accept_header}" "localhost:5555${path}" | tr -d '\0')
           local http_code=$(echo "$response" | tail -n1)
           local json_response=$(echo "$response" | sed '$d')
           if [[ $http_code -ge 200 && $http_code -lt 300 ]]; then
@@ -143,18 +143,25 @@ runs:
           fi
           echo "Extracted finalized root: $finalized_root"
 
-          echo "Checking endpoint /eth/v2/debug/beacon/states/$finalized_root with accept header application/octet-stream..."
-          finalized_state=$(check_endpoint "/eth/v2/debug/beacon/states/$finalized_root" "application/octet-stream")
-          [[ $? -ne 0 ]] && continue
-          echo "Finalized state is available."
-
           echo "Checking endpoint /eth/v2/beacon/blocks/$finalized_root with accept header application/json..."
           finalized_block=$(check_endpoint "/eth/v2/beacon/blocks/$finalized_root" "application/json")
           [[ $? -ne 0 ]] && continue
           echo "Finalized block is available."
 
+          finalized_state_root=$(echo $finalized_block | jq -r '.data.message.state_root')
+          if [[ -z "$finalized_state_root" ]]; then
+            echo "Failed to extract finalized state root from the finalized block."
+            continue
+          fi
+          echo "Extracted finalized state root: $finalized_state_root"
+
+          echo "Checking endpoint /eth/v2/debug/beacon/states/$finalized_state_root with accept header application/octet-stream..."
+          finalized_state=$(check_endpoint "/eth/v2/debug/beacon/states/$finalized_state_root" "application/octet-stream")
+          [[ $? -ne 0 ]] && continue
+          echo "Finalized state is available."
+
           echo "Fetching slot from /eth/v2/beacon/blocks/$finalized_root..."
-          finalized_slot=$(curl -s -H "accept: application/json" "localhost:5555/eth/v2/beacon/blocks/$finalized_root" | jq -r '.data.message.slot')
+          finalized_slot=$(echo $finalized_block | jq -r '.data.message.slot')
           if [[ -z "$finalized_slot" ]]; then
             echo "Failed to extract slot from the finalized block."
             continue

--- a/.github/actions/checkpoint-sync/action.yaml
+++ b/.github/actions/checkpoint-sync/action.yaml
@@ -46,7 +46,7 @@ runs:
         beacon:
           upstreams:
           - name: state-provider
-            address: https://checkpoint-sync.${{ inputs.network }}.ethpandaops.io
+            address: $beacon_node
             timeoutSeconds: 30
             dataProvider: true
         checkpointz:

--- a/.github/actions/checkpoint-sync/action.yaml
+++ b/.github/actions/checkpoint-sync/action.yaml
@@ -78,7 +78,6 @@ runs:
         echo "Checkpointz has the genesis block.";
     - name: Manually check endpoints
       shell: bash
-      timeout: 10m
       run: |
         check_endpoint() {
           local path=$1

--- a/.github/actions/checkpoint-sync/action.yaml
+++ b/.github/actions/checkpoint-sync/action.yaml
@@ -93,10 +93,11 @@ runs:
         check_endpoint() {
           local path=$1
           local accept_header=$2
-          local response=$(curl -s -H "accept: ${accept_header}" "localhost:5555${path}")
-          local http_code=$(curl -s -o /dev/null -w "%{http_code}" -H "accept: ${accept_header}" "localhost:5555${path}")
+          local response=$(curl -s -w "\n%{http_code}" -H "accept: ${accept_header}" "localhost:5555${path}")
+          local http_code=$(echo "$response" | tail -n1)
+          local json_response=$(echo "$response" | sed '$d')
           if [[ $http_code -ge 200 && $http_code -lt 300 ]]; then
-            echo $response
+            echo $json_response
             return 0
           else
             echo "Endpoint ${path} with accept header ${accept_header} is not available."

--- a/.github/actions/checkpoint-sync/action.yaml
+++ b/.github/actions/checkpoint-sync/action.yaml
@@ -92,32 +92,32 @@ runs:
         check_endpoint() {
           local path=$1
           local accept_header=$2
-          echo "Checking endpoint ${path} with accept header ${accept_header}..."
           local response=$(curl -s -o /dev/null -w "%{http_code}" -H "accept: ${accept_header}" "localhost:5555${path}")
           if [[ $response -ge 200 && $response -lt 300 ]]; then
-            echo "Endpoint ${path} with accept header ${accept_header} is available."
             return 0
           else
             echo "Endpoint ${path} with accept header ${accept_header} is not available."
-            echo "Response: ${response}"
             return 1
           fi
         }
+        fails=0
 
         while true; do
-          sleep 1;
-          genesis_block=$(check_endpoint "/eth/v2/beacon/blocks/genesis" "application/json")
-          if [[ $? -ne 0 ]]; then
-            continue
+          if [[ $fails -gt 0 ]]; then
+            echo "Failed $fails times, retrying..."
+            sleep 1;
           fi
+          echo "Checking endpoint /eth/v2/beacon/blocks/genesis with accept header application/json..."
+          genesis_block=$(check_endpoint "/eth/v2/beacon/blocks/genesis" "application/json")
+          [[ $? -ne 0 ]] && continue
           echo "Genesis block is available."
 
+          echo "Checking endpoint /eth/v2/beacon/states/genesis with accept header application/octet-stream..."
           genesis_state=$(check_endpoint "/eth/v2/beacon/states/genesis" "application/octet-stream")
-          if [[ $? -ne 0 ]]; then
-            continue
-          fi
+          [[ $? -ne 0 ]] && continue
           echo "Genesis state is available."
 
+          echo "Checking endpoint /eth/v1/beacon/states/finalized/finality_checkpoints with accept header application/json..."
           finality_checkpoints=$(check_endpoint "/eth/v1/beacon/states/finalized/finality_checkpoints" "application/json")
           if [[ $? -ne 0 ]]; then
             echo "Finality checkpoints endpoint is not available."
@@ -125,24 +125,25 @@ runs:
           fi
           echo "Finality checkpoints endpoint is available."
 
-          finalized_root=$(echo $finality_checkpoints | jq -r '.data.finalized.root')
+          echo "Fetching finalized root from /eth/v1/beacon/states/finalized/finality_checkpoints..."
+          finalized_root=$(curl -s -H "accept: application/json" "localhost:5555/eth/v1/beacon/states/finalized/finality_checkpoints" | jq -r '.data.finalized.root')
+          if [[ -z "$finalized_root" ]]; then
+            echo "Failed to extract finalized root from the finality checkpoints."
+            continue
+          fi
           echo "Extracted finalized root: $finalized_root"
 
+          echo "Checking endpoint /eth/v2/beacon/states/$finalized_root with accept header application/octet-stream..."
           finalized_state=$(check_endpoint "/eth/v2/beacon/states/$finalized_root" "application/octet-stream")
-          if [[ $? -ne 0 ]]; then
-            echo "Finalized state endpoint is not available."
-            continue
-          fi
+          [[ $? -ne 0 ]] && continue
           echo "Finalized state is available."
 
+          echo "Checking endpoint /eth/v2/beacon/blocks/$finalized_root with accept header application/json..."
           finalized_block=$(check_endpoint "/eth/v2/beacon/blocks/$finalized_root" "application/json")
-          if [[ $? -ne 0 ]]; then
-            echo "Finalized block endpoint is not available."
-            continue
-          fi
+          [[ $? -ne 0 ]] && continue
           echo "Finalized block is available."
 
-          # Extract the slot from the finalized block
+          echo "Fetching slot from /eth/v2/beacon/blocks/$finalized_root..."
           finalized_slot=$(curl -s -H "accept: application/json" "localhost:5555/eth/v2/beacon/blocks/$finalized_root" | jq -r '.data.message.slot')
           if [[ -z "$finalized_slot" ]]; then
             echo "Failed to extract slot from the finalized block."
@@ -150,19 +151,14 @@ runs:
           fi
           echo "Extracted slot: $finalized_slot"
 
+          echo "Checking endpoint /eth/v2/beacon/blocks/$finalized_slot with accept header application/json..."
           block=$(check_endpoint "/eth/v2/beacon/blocks/$finalized_slot" "application/json")
-          if [[ $? -ne 0 ]]; then
-            echo "Block for finalized slot $finalized_slot is not available."
-            continue
-          fi
+          [[ $? -ne 0 ]] && continue
           echo "Block for finalized slot $finalized_slot is available."
 
-          # Check if we can fetch the block via 'finalized'
+          echo "Checking endpoint /eth/v2/beacon/blocks/finalized with accept header application/json..."
           finalized_block_via_finalized=$(check_endpoint "/eth/v2/beacon/blocks/finalized" "application/json")
-          if [[ $? -ne 0 ]]; then
-            echo "Finalized block via 'finalized' endpoint is not available."
-            continue
-          fi
+          [[ $? -ne 0 ]] && continue
           echo "Finalized block via 'finalized' endpoint is available."
 
           echo "All endpoints are available."

--- a/.github/actions/checkpoint-sync/action.yaml
+++ b/.github/actions/checkpoint-sync/action.yaml
@@ -93,8 +93,10 @@ runs:
         check_endpoint() {
           local path=$1
           local accept_header=$2
-          local response=$(curl -s -o /dev/null -w "%{http_code}" -H "accept: ${accept_header}" "localhost:5555${path}")
-          if [[ $response -ge 200 && $response -lt 300 ]]; then
+          local response=$(curl -s -H "accept: ${accept_header}" "localhost:5555${path}")
+          local http_code=$(curl -s -o /dev/null -w "%{http_code}" -H "accept: ${accept_header}" "localhost:5555${path}")
+          if [[ $http_code -ge 200 && $http_code -lt 300 ]]; then
+            echo $response
             return 0
           else
             echo "Endpoint ${path} with accept header ${accept_header} is not available."

--- a/.github/actions/checkpoint-sync/action.yaml
+++ b/.github/actions/checkpoint-sync/action.yaml
@@ -115,10 +115,15 @@ runs:
           [[ $? -ne 0 ]] && continue
           echo "Genesis block is available."
 
-          echo "Checking endpoint /eth/v2/beacon/states/genesis with accept header application/octet-stream..."
-          genesis_state=$(check_endpoint "/eth/v2/beacon/states/genesis" "application/octet-stream")
+          echo "Checking endpoint /eth/v2/debug/beacon/states/genesis with accept header application/octet-stream..."
+          genesis_state=$(check_endpoint "/eth/v2/debug/beacon/states/genesis" "application/octet-stream")
           [[ $? -ne 0 ]] && continue
           echo "Genesis state is available."
+
+          echo "Checking endpoint /eth/v2/debug/beacon/states/finalized with accept header application/octet-stream..."
+          finalized_state=$(check_endpoint "/eth/v2/debug/beacon/states/finalized" "application/octet-stream")
+          [[ $? -ne 0 ]] && continue
+          echo "Finalized state is available."
 
           echo "Checking endpoint /eth/v1/beacon/states/finalized/finality_checkpoints with accept header application/json..."
           finality_checkpoints=$(check_endpoint "/eth/v1/beacon/states/finalized/finality_checkpoints" "application/json")
@@ -128,16 +133,15 @@ runs:
           fi
           echo "Finality checkpoints endpoint is available."
 
-          echo "Fetching finalized root from /eth/v1/beacon/states/finalized/finality_checkpoints..."
-          finalized_root=$(curl -s -H "accept: application/json" "localhost:5555/eth/v1/beacon/states/finalized/finality_checkpoints" | jq -r '.data.finalized.root')
+          finalized_root=$(echo $finality_checkpoints | jq -r '.data.finalized.root')
           if [[ -z "$finalized_root" ]]; then
             echo "Failed to extract finalized root from the finality checkpoints."
             continue
           fi
           echo "Extracted finalized root: $finalized_root"
 
-          echo "Checking endpoint /eth/v2/beacon/states/$finalized_root with accept header application/octet-stream..."
-          finalized_state=$(check_endpoint "/eth/v2/beacon/states/$finalized_root" "application/octet-stream")
+          echo "Checking endpoint /eth/v2/debug/beacon/states/$finalized_root with accept header application/octet-stream..."
+          finalized_state=$(check_endpoint "/eth/v2/debug/beacon/states/$finalized_root" "application/octet-stream")
           [[ $? -ne 0 ]] && continue
           echo "Finalized state is available."
 

--- a/.github/actions/checkpoint-sync/action.yaml
+++ b/.github/actions/checkpoint-sync/action.yaml
@@ -28,6 +28,16 @@ runs:
     - name: Configure checkpointz
       shell: bash
       run: |
+        beacon_node=""
+        if [[ ${{ inputs.network }} == "mainnet" ]]; then
+          beacon_node="http://testing.mainnet.beacon-api.nimbus.team/"
+        elif [[ ${{ inputs.network }} == "holesky" ]]; then
+          beacon_node="http://testing.holesky.beacon-api.nimbus.team/"
+        else
+          echo "Unsupported network: ${{ inputs.network }}"
+          exit 1
+        fi
+
         cat <<EOF > checkpointz.yaml
         global:
           listenAddr: ":5555"
@@ -89,6 +99,7 @@ runs:
             return 0
           else
             echo "Endpoint ${path} with accept header ${accept_header} is not available."
+            echo "Response: ${response}"
             return 1
           fi
         }

--- a/.github/actions/checkpoint-sync/action.yaml
+++ b/.github/actions/checkpoint-sync/action.yaml
@@ -89,6 +89,7 @@ runs:
     - name: Manually check endpoints
       shell: bash
       run: |
+        set +e
         check_endpoint() {
           local path=$1
           local accept_header=$2
@@ -107,6 +108,8 @@ runs:
             echo "Failed $fails times, retrying..."
             sleep 1;
           fi
+          fails=$((fails+1))
+          
           echo "Checking endpoint /eth/v2/beacon/blocks/genesis with accept header application/json..."
           genesis_block=$(check_endpoint "/eth/v2/beacon/blocks/genesis" "application/json")
           [[ $? -ne 0 ]] && continue

--- a/.github/actions/checkpoint-sync/action.yaml
+++ b/.github/actions/checkpoint-sync/action.yaml
@@ -76,6 +76,88 @@ runs:
         echo "Waiting for checkpointz to have the genesis block...";
         bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:5555/eth/v2/beacon/blocks/0)" != "200" ]]; do sleep 1; done';
         echo "Checkpointz has the genesis block.";
+    - name: Manually check endpoints
+      shell: bash
+      timeout: 10m
+      run: |
+        check_endpoint() {
+          local path=$1
+          local accept_header=$2
+          echo "Checking endpoint ${path} with accept header ${accept_header}..."
+          local response=$(curl -s -o /dev/null -w "%{http_code}" -H "accept: ${accept_header}" "localhost:5555${path}")
+          if [[ $response -ge 200 && $response -lt 300 ]]; then
+            echo "Endpoint ${path} with accept header ${accept_header} is available."
+            return 0
+          else
+            echo "Endpoint ${path} with accept header ${accept_header} is not available."
+            return 1
+          fi
+        }
+
+        while true; do
+          sleep 1;
+          genesis_block=$(check_endpoint "/eth/v2/beacon/blocks/genesis" "application/json")
+          if [[ $? -ne 0 ]]; then
+            continue
+          fi
+          echo "Genesis block is available."
+
+          genesis_state=$(check_endpoint "/eth/v2/beacon/states/genesis" "application/octet-stream")
+          if [[ $? -ne 0 ]]; then
+            continue
+          fi
+          echo "Genesis state is available."
+
+          finality_checkpoints=$(check_endpoint "/eth/v1/beacon/states/finalized/finality_checkpoints" "application/json")
+          if [[ $? -ne 0 ]]; then
+            echo "Finality checkpoints endpoint is not available."
+            continue
+          fi
+          echo "Finality checkpoints endpoint is available."
+
+          finalized_root=$(echo $finality_checkpoints | jq -r '.data.finalized.root')
+          echo "Extracted finalized root: $finalized_root"
+
+          finalized_state=$(check_endpoint "/eth/v2/beacon/states/$finalized_root" "application/octet-stream")
+          if [[ $? -ne 0 ]]; then
+            echo "Finalized state endpoint is not available."
+            continue
+          fi
+          echo "Finalized state is available."
+
+          finalized_block=$(check_endpoint "/eth/v2/beacon/blocks/$finalized_root" "application/json")
+          if [[ $? -ne 0 ]]; then
+            echo "Finalized block endpoint is not available."
+            continue
+          fi
+          echo "Finalized block is available."
+
+          # Extract the slot from the finalized block
+          finalized_slot=$(curl -s -H "accept: application/json" "localhost:5555/eth/v2/beacon/blocks/$finalized_root" | jq -r '.data.message.slot')
+          if [[ -z "$finalized_slot" ]]; then
+            echo "Failed to extract slot from the finalized block."
+            continue
+          fi
+          echo "Extracted slot: $finalized_slot"
+
+          block=$(check_endpoint "/eth/v2/beacon/blocks/$finalized_slot" "application/json")
+          if [[ $? -ne 0 ]]; then
+            echo "Block for finalized slot $finalized_slot is not available."
+            continue
+          fi
+          echo "Block for finalized slot $finalized_slot is available."
+
+          # Check if we can fetch the block via 'finalized'
+          finalized_block_via_finalized=$(check_endpoint "/eth/v2/beacon/blocks/finalized" "application/json")
+          if [[ $? -ne 0 ]]; then
+            echo "Finalized block via 'finalized' endpoint is not available."
+            continue
+          fi
+          echo "Finalized block via 'finalized' endpoint is available."
+
+          echo "All endpoints are available."
+          break;
+        done;
     - name: Run teku client
       shell: bash
       if:  ${{ inputs.consensus == 'teku' }}

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -10,10 +10,8 @@ jobs:
     permissions:
       contents: write
     runs-on:
-      - environment=production
-      - size=xlarge
-      - provider=ethpandaops
-      - realm=platform
+      - self-hosted-ghr
+      - size-l-x64
     steps:
       -
         name: Checkout

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -15,7 +15,7 @@ jobs:
         consensus: [lighthouse, teku, prysm, nimbus, lodestar]
         network: [mainnet]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - name: Print details

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         consensus: [lighthouse, teku, prysm, nimbus, lodestar]
-        network: [sepolia]
+        network: [mainnet]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/manual-integration.yaml
+++ b/.github/workflows/manual-integration.yaml
@@ -11,7 +11,7 @@ on:
         description: 'Networks to use'    
         required: true
         type: string
-        default: ropsten, sepolia, goerli
+        default: mainnet, sepolia, holesky
 
 jobs:
   init:

--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -613,7 +613,7 @@ func (d *Default) GetBlobSidecarsBySlot(ctx context.Context, slot phase0.Slot) (
 	return d.blobSidecars.GetBySlot(slot)
 }
 
-func (d *Default) GetBeaconStateBySlot(ctx context.Context, slot phase0.Slot) (*[]byte, error) {
+func (d *Default) GetBeaconStateBySlot(ctx context.Context, slot phase0.Slot) (*spec.VersionedBeaconState, error) {
 	block, err := d.GetBlockBySlot(ctx, slot)
 	if err != nil {
 		return nil, err
@@ -627,11 +627,11 @@ func (d *Default) GetBeaconStateBySlot(ctx context.Context, slot phase0.Slot) (*
 	return d.states.GetByStateRoot(stateRoot)
 }
 
-func (d *Default) GetBeaconStateByStateRoot(ctx context.Context, stateRoot phase0.Root) (*[]byte, error) {
+func (d *Default) GetBeaconStateByStateRoot(ctx context.Context, stateRoot phase0.Root) (*spec.VersionedBeaconState, error) {
 	return d.states.GetByStateRoot(stateRoot)
 }
 
-func (d *Default) GetBeaconStateByRoot(ctx context.Context, root phase0.Root) (*[]byte, error) {
+func (d *Default) GetBeaconStateByRoot(ctx context.Context, root phase0.Root) (*spec.VersionedBeaconState, error) {
 	block, err := d.GetBlockByRoot(ctx, root)
 	if err != nil {
 		return nil, err

--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -357,7 +357,10 @@ func (d *Default) fetchBundle(ctx context.Context, root phase0.Root, upstream *N
 		}
 	}
 
-	d.log.WithField("root", eth.RootAsString(root)).Infof("Successfully fetched bundle from %s", upstream.Config.Name)
+	d.log.WithFields(logrus.Fields{
+		"block_root": eth.RootAsString(root),
+		"state_root": eth.RootAsString(stateRoot),
+	}).Infof("Successfully fetched bundle from %s", upstream.Config.Name)
 
 	return block, nil
 }

--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -369,7 +369,7 @@ func (d *Default) downloadAndStoreBeaconState(ctx context.Context, stateRoot pha
 		return nil
 	}
 
-	beaconState, err := node.Beacon.FetchRawBeaconState(ctx, eth.SlotAsString(slot), "application/octet-stream")
+	beaconState, err := node.Beacon.FetchBeaconState(ctx, eth.SlotAsString(slot))
 	if err != nil {
 		return fmt.Errorf("failed to fetch beacon state: %w", err)
 	}
@@ -383,7 +383,7 @@ func (d *Default) downloadAndStoreBeaconState(ctx context.Context, stateRoot pha
 		expiresAt = time.Now().Add(999999 * time.Hour)
 	}
 
-	if err := d.states.Add(stateRoot, &beaconState, expiresAt, slot); err != nil {
+	if err := d.states.Add(stateRoot, beaconState, expiresAt, slot); err != nil {
 		return fmt.Errorf("failed to store beacon state: %w", err)
 	}
 

--- a/pkg/beacon/finality_provider.go
+++ b/pkg/beacon/finality_provider.go
@@ -43,11 +43,11 @@ type FinalityProvider interface {
 	// GetBlockByStateRoot returns the block with the given root.
 	GetBlockByStateRoot(ctx context.Context, root phase0.Root) (*spec.VersionedSignedBeaconBlock, error)
 	// GetBeaconStateBySlot returns the beacon sate with the given slot.
-	GetBeaconStateBySlot(ctx context.Context, slot phase0.Slot) (*[]byte, error)
+	GetBeaconStateBySlot(ctx context.Context, slot phase0.Slot) (*spec.VersionedBeaconState, error)
 	// GetBeaconStateByStateRoot returns the beacon sate with the given state root.
-	GetBeaconStateByStateRoot(ctx context.Context, root phase0.Root) (*[]byte, error)
+	GetBeaconStateByStateRoot(ctx context.Context, root phase0.Root) (*spec.VersionedBeaconState, error)
 	// GetBeaconStateByRoot returns the beacon sate with the given root.
-	GetBeaconStateByRoot(ctx context.Context, root phase0.Root) (*[]byte, error)
+	GetBeaconStateByRoot(ctx context.Context, root phase0.Root) (*spec.VersionedBeaconState, error)
 	// GetBlobSidecarsBySlot returns the blob sidecars for the given slot.
 	GetBlobSidecarsBySlot(ctx context.Context, slot phase0.Slot) ([]*deneb.BlobSidecar, error)
 	// ListFinalizedSlots returns a slice of finalized slots.

--- a/pkg/beacon/store/state.go
+++ b/pkg/beacon/store/state.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/ethpandaops/checkpointz/pkg/cache"
 	"github.com/ethpandaops/checkpointz/pkg/eth"
@@ -30,7 +31,7 @@ func NewBeaconState(log logrus.FieldLogger, config Config, namespace string) *Be
 	return c
 }
 
-func (c *BeaconState) Add(stateRoot phase0.Root, state *[]byte, expiresAt time.Time, slot phase0.Slot) error {
+func (c *BeaconState) Add(stateRoot phase0.Root, state *spec.VersionedBeaconState, expiresAt time.Time, slot phase0.Slot) error {
 	invincible := false
 	if slot == 0 {
 		invincible = true
@@ -48,7 +49,7 @@ func (c *BeaconState) Add(stateRoot phase0.Root, state *[]byte, expiresAt time.T
 	return nil
 }
 
-func (c *BeaconState) GetByStateRoot(stateRoot phase0.Root) (*[]byte, error) {
+func (c *BeaconState) GetByStateRoot(stateRoot phase0.Root) (*spec.VersionedBeaconState, error) {
 	data, _, err := c.store.Get(eth.RootAsString(stateRoot))
 	if err != nil {
 		return nil, err
@@ -57,8 +58,8 @@ func (c *BeaconState) GetByStateRoot(stateRoot phase0.Root) (*[]byte, error) {
 	return c.parseState(data)
 }
 
-func (c *BeaconState) parseState(data interface{}) (*[]byte, error) {
-	state, ok := data.(*[]byte)
+func (c *BeaconState) parseState(data interface{}) (*spec.VersionedBeaconState, error) {
+	state, ok := data.(*spec.VersionedBeaconState)
 	if !ok {
 		return nil, errors.New("invalid state")
 	}

--- a/pkg/service/eth/eth.go
+++ b/pkg/service/eth/eth.go
@@ -267,7 +267,7 @@ func (h *Handler) PeerCount(ctx context.Context) (uint64, error) {
 }
 
 // BeaconState returns the beacon state for the given state id.
-func (h *Handler) BeaconState(ctx context.Context, stateID StateIdentifier) (*[]byte, error) {
+func (h *Handler) BeaconState(ctx context.Context, stateID StateIdentifier) (*spec.VersionedBeaconState, error) {
 	var err error
 
 	const call = "beacon_state"


### PR DESCRIPTION
This PR changes how Checkpointz parses `beacon state` objects. Previously we just stored the raw bytes that were received from the upstream beacon node. This was becoming more and more painful as we try to comply with the Beacon API Spec as much as possible. We now fetch the state, parse it in to a struct, and marshal it to SSZ when someone requests it, allowing us to be more compliant with the Beacon API Spec.