### PR TITLE
add `curl` to debian docker images

### DIFF
--- a/goreleaser-debian.Dockerfile
+++ b/goreleaser-debian.Dockerfile
@@ -2,6 +2,7 @@ FROM debian:latest
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \
+  curl \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 COPY checkpointz* /checkpointz


### PR DESCRIPTION
This PR adds the `curl` package to the debian docker images.
Having a base utility for http requests within the container is very helpful for customized liveness probes, which require fetching some APIs and check the results to see if checkpointz is still fine.