### PR TITLE
fix: update go-eth2-client dependency to v0.24.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ethpandaops/checkpointz
 go 1.22
 
 require (
-	github.com/attestantio/go-eth2-client v0.24.0
+	github.com/attestantio/go-eth2-client v0.24.1-0.20250219090147-b41ce952806c
 	github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9
 	github.com/creasty/defaults v1.6.0
 	github.com/ethpandaops/beacon v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/attestantio/go-eth2-client v0.24.0 h1:lGVbcnhlBwRglt1Zs56JOCgXVyLWKFZOmZN8jKhE7Ws=
-github.com/attestantio/go-eth2-client v0.24.0/go.mod h1:/KTLN3WuH1xrJL7ZZrpBoWM1xCCihnFbzequD5L+83o=
+github.com/attestantio/go-eth2-client v0.24.1-0.20250219090147-b41ce952806c h1:i1p3AyXvNfUffEKAnnnoJVfDBYLRPLa/BQ8q5Mf+kY0=
+github.com/attestantio/go-eth2-client v0.24.1-0.20250219090147-b41ce952806c/go.mod h1:/KTLN3WuH1xrJL7ZZrpBoWM1xCCihnFbzequD5L+83o=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/btcsuite/btcd/btcec/v2 v2.3.4 h1:3EJjcN70HCu/mwqlUsGK8GcNVyLVxFDlWurTXGPFfiQ=


### PR DESCRIPTION
```
time="2025-02-21T19:01:08Z" level=info msg="Serving bundle is unknown, downloading" head_epoch=115263 head_root=0x6477384a39222d83e052fac778d0b906c3643f8f565fecd58f08123c8b5ce1d4 module=beacon/default
time="2025-02-21T19:01:08Z" level=info msg="Downloading serving checkpoint" epoch=115263 fork_name=deneb module=beacon/default
time="2025-02-21T19:01:08Z" level=info msg="Fetching bundle from node Nethermind + Lighthouse (self-hosted) with root 0x6477384a39222d83e052fac778d0b906c3643f8f565fecd58f08123c8b5ce1d4" module=beacon/default
time="2025-02-21T19:01:08Z" level=info msg="Fetched beacon block" module=beacon/default root=0x6477384a39222d83e052fac778d0b906c3643f8f565fecd58f08123c8b5ce1d4 slot=3688416 state_root=0x21d750a8a08a5946bb0bab4acc393d5efc6a025d1ac78ef8631df8f4a9d9ecdc
time="2025-02-21T19:01:12Z" level=error msg="Failed to check for new serving checkpoint" error="failed to fetch bundle: failed to download and store blob sidecars: failed to parse JSON\nEOF" module=beacon/default
```

Fix for this issue - thanks for the logs @remyroy!