### PR TITLE
refactor: return nil when error has already been checked

### DIFF
--- a/pkg/cache/ttl.go
+++ b/pkg/cache/ttl.go
@@ -175,7 +175,7 @@ func (m *TTLMap) Get(k string) (interface{}, time.Time, error) {
 		return nil, time.Now(), err
 	}
 
-	return itv, expires, err
+	return itv, expires, nil
 }
 
 func (m *TTLMap) get(k string) (interface{}, time.Time, error) {


### PR DESCRIPTION
Since we have already checked err before and returned when err != nil, err must be nil here. Return nil directly to make the code clearer.