### PR TITLE
chore: replace renovate with dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+   - package-ecosystem: github-actions
+     directory: /
+     schedule:
+        interval: weekly
+     groups:
+        actions:
+           patterns:
+              - '*'
+   - package-ecosystem: gomod
+     directory: /
+     schedule:
+        interval: weekly
+     groups:
+        go-dependencies:
+           patterns:
+              - '*'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters-settings:
       - performance
       - style
   govet:
-    check-shadowing: true
+    shadow: true
   nolintlint:
     require-explanation: true
     require-specific: true

--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -173,6 +173,7 @@ func (d *Default) fetchHistoricalCheckpoints(ctx context.Context, checkpoint *v1
 	// We'll derive the current finalized slot and then work back in intervals of SLOTS_PER_EPOCH.
 	currentSlot := uint64(checkpoint.Finalized.Epoch) * uint64(sp.SlotsPerEpoch)
 	for i := 1; i < d.config.HistoricalEpochCount; i++ {
+		//nolint:gosec // This is not a security issue
 		if uint64(i)*uint64(sp.SlotsPerEpoch) > currentSlot {
 			break
 		}

--- a/pkg/service/eth/eth.go
+++ b/pkg/service/eth/eth.go
@@ -456,7 +456,6 @@ func (h *Handler) BlobSidecars(ctx context.Context, blockID BlockIdentifier, ind
 
 	switch blockID.Type() {
 	case BlockIDGenesis:
-		//nolint:govet // False positive
 		block, err := h.provider.GetBlockBySlot(ctx, phase0.Slot(0))
 		if err != nil {
 			return nil, err
@@ -473,7 +472,6 @@ func (h *Handler) BlobSidecars(ctx context.Context, blockID BlockIdentifier, ind
 
 		slot = sl
 	case BlockIDSlot:
-		//nolint:govet // False positive
 		sslot, err := NewSlotFromString(blockID.Value())
 		if err != nil {
 			return nil, err
@@ -495,7 +493,6 @@ func (h *Handler) BlobSidecars(ctx context.Context, blockID BlockIdentifier, ind
 
 		slot = sl
 	case BlockIDRoot:
-		//nolint:govet // False positive
 		root, err := blockID.AsRoot()
 		if err != nil {
 			return nil, err
@@ -517,7 +514,6 @@ func (h *Handler) BlobSidecars(ctx context.Context, blockID BlockIdentifier, ind
 
 		slot = sl
 	case BlockIDFinalized:
-		//nolint:govet // False positive
 		finality, err := h.provider.Finalized(ctx)
 		if err != nil {
 			return nil, err

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
-}


### PR DESCRIPTION
This commit replaces Renovate with Dependabot for managing dependency updates. Dependabot is configured to update GitHub Actions and Go module dependencies weekly.
Renovate configuration file is removed.