### PR TITLE
chore(deps): bump ethpandaops/go-eth2-client to v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/creasty/defaults v1.6.0
 	github.com/ethpandaops/beacon v0.67.1-0.20260414085454-4de46d12471e
 	github.com/ethpandaops/ethwallclock v0.2.0
-	github.com/ethpandaops/go-eth2-client v0.0.1
+	github.com/ethpandaops/go-eth2-client v0.1.0
 	github.com/go-co-op/gocron v1.18.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/nanmu42/gzip v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/ethpandaops/beacon v0.67.1-0.20260414085454-4de46d12471e h1:SVNjoOoy1
 github.com/ethpandaops/beacon v0.67.1-0.20260414085454-4de46d12471e/go.mod h1:huTiadnAh+6EfLqDu+HhI72Zfr2alJh4tjTt5Rt7C2g=
 github.com/ethpandaops/ethwallclock v0.2.0 h1:EeFKtZ7v6TAdn/oAh0xaPujD7N4amjBxrWIByraUfLM=
 github.com/ethpandaops/ethwallclock v0.2.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/go-eth2-client v0.0.1 h1:Xifvb7RF24tguA6HxEaE2vIN1BsY44SOSH/B+CBSFPk=
-github.com/ethpandaops/go-eth2-client v0.0.1/go.mod h1:9BBd/XIw1egZTkxtFGMvgXnsxX6ypKHKNKD7itqjmNQ=
+github.com/ethpandaops/go-eth2-client v0.1.0 h1:migUQIIL3fcWWMmIwF4Rh05rvJPuj+LOgDJkIWZ+gIE=
+github.com/ethpandaops/go-eth2-client v0.1.0/go.mod h1:9BBd/XIw1egZTkxtFGMvgXnsxX6ypKHKNKD7itqjmNQ=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=


### PR DESCRIPTION
## Summary
- Bumps `github.com/ethpandaops/go-eth2-client` from `v0.0.1` to `v0.1.0`.

## Test plan
- [ ] `go build ./...` passes
- [ ] CI passes