### PR TITLE
fix: prevent uint64 underflow in ListFinalizedSlots on short-lived chains

### DIFF
--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -748,9 +748,18 @@ func (d *Default) ListFinalizedSlots(ctx context.Context) ([]phase0.Slot, error)
 		return slots, errors.New("no finalized checkpoint available")
 	}
 
-	latestSlot := phase0.Slot(uint64(finality.Finalized.Epoch) * uint64(sp.SlotsPerEpoch))
+	latestSlot := uint64(finality.Finalized.Epoch) * uint64(sp.SlotsPerEpoch)
+	//nolint:gosec // HistoricalEpochCount is validated as positive in config.
+	lookback := uint64(sp.SlotsPerEpoch) * uint64(d.config.HistoricalEpochCount)
 
-	for i, val := uint64(latestSlot), uint64(latestSlot)-uint64(sp.SlotsPerEpoch)*uint64(d.config.HistoricalEpochCount); i > val; i -= uint64(sp.SlotsPerEpoch) { //nolint:gosec // values are always positive
+	// Clamp the lower bound at 0 so short-lived chains (finalized epoch <
+	// HistoricalEpochCount) don't underflow uint64 and skip the loop entirely.
+	var earliest uint64
+	if latestSlot > lookback {
+		earliest = latestSlot - lookback
+	}
+
+	for i := latestSlot; i > earliest; i -= uint64(sp.SlotsPerEpoch) {
 		slots = append(slots, phase0.Slot(i))
 	}
 


### PR DESCRIPTION
## Summary
- `ListFinalizedSlots` (backing `GET /checkpointz/v1/beacon/slots`) computed its lower-bound slot as `latestSlot - SlotsPerEpoch * HistoricalEpochCount` in `uint64`. When the finalized epoch is smaller than `historical_epoch_count` — e.g. during the first ~2 minutes of a freshly started devnet or a kurtosis enclave — the subtraction underflows to ~2^64, so the `i > val` loop condition is immediately false and the function returns an empty slice. The UI's "historical finalized epoch boundaries" table then stays blank until the chain has produced `HistoricalEpochCount` (default 20) epochs.
- Clamp the lower bound at 0 so every available finalized epoch-boundary slot is returned, regardless of chain age. No behavior change once `finalizedEpoch >= HistoricalEpochCount`.

## Repro
Spin up a kurtosis enclave that produces epochs quickly (e.g. gloas devnet, `SLOTS_PER_EPOCH=8`) and hit `/checkpointz/v1/beacon/slots` while `finalizedEpoch < 20`:

```
$ curl .../checkpointz/v1/beacon/slots
{"data":{"slots":[]}}
```

Bundle fetching and `/eth/v2/beacon/blocks/finalized` work fine — only the UI's history list is affected.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/master ./pkg/beacon/...` → 0 issues
- [ ] Rebuild image, rerun kurtosis enclave, verify `/checkpointz/v1/beacon/slots` returns non-empty list before epoch 20 and that the UI populates the historical-checkpoints table