### PR TITLE
fix(gloas): prevent uint64 underflow in ListFinalizedSlots on short-lived chains

### DIFF
--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -748,10 +748,18 @@ func (d *Default) ListFinalizedSlots(ctx context.Context) ([]phase0.Slot, error)
 		return slots, errors.New("no finalized checkpoint available")
 	}
 
-	latestSlot := phase0.Slot(uint64(finality.Finalized.Epoch) * uint64(sp.SlotsPerEpoch))
-
+	latestSlot := uint64(finality.Finalized.Epoch) * uint64(sp.SlotsPerEpoch)
 	//nolint:gosec // HistoricalEpochCount is validated as positive in config.
-	for i, val := uint64(latestSlot), uint64(latestSlot)-uint64(sp.SlotsPerEpoch)*uint64(d.config.HistoricalEpochCount); i > val; i -= uint64(sp.SlotsPerEpoch) {
+	lookback := uint64(sp.SlotsPerEpoch) * uint64(d.config.HistoricalEpochCount)
+
+	// Clamp the lower bound at 0 so short-lived chains (finalized epoch <
+	// HistoricalEpochCount) don't underflow uint64 and skip the loop entirely.
+	var earliest uint64
+	if latestSlot > lookback {
+		earliest = latestSlot - lookback
+	}
+
+	for i := latestSlot; i > earliest; i -= uint64(sp.SlotsPerEpoch) {
 		slots = append(slots, phase0.Slot(i))
 	}
 


### PR DESCRIPTION
## Summary
- Same fix as #241, targeted at `release/gloas` so gloas devnets / kurtosis enclaves can pick it up immediately without waiting for a master merge.
- `ListFinalizedSlots` (backing `GET /checkpointz/v1/beacon/slots`) computed its lower-bound slot as `latestSlot - SlotsPerEpoch * HistoricalEpochCount` in `uint64`. When the finalized epoch is smaller than `historical_epoch_count` — typical for the first ~2 minutes of a kurtosis gloas enclave with `SLOTS_PER_EPOCH=8` and the default `historical_epoch_count=20` — the subtraction underflows to ~2^64, so the `i > val` loop condition is immediately false and the endpoint returns an empty slice. UI "historical finalized epoch boundaries" table then stays blank.
- Clamp the lower bound at 0 so every available finalized epoch-boundary slot is returned, regardless of chain age. No behavior change once `finalizedEpoch >= HistoricalEpochCount`.

## Repro (on release/gloas before this patch)
```
$ curl .../checkpointz/v1/beacon/slots
{"data":{"slots":[]}}
```
After: the list returns whatever's available (1 entry after the first finalized epoch, 2 after the second, …).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/release/gloas ./pkg/beacon/...` → 0 issues
- [x] Verified in a running kurtosis gloas enclave: rows populate incrementally from epoch 1 onward instead of staying empty until epoch 20