### PR TITLE
fix(web): flag serving checkpoint by block root, not epoch

### DIFF
--- a/web/src/parts/checkpoints/Checkpoints.tsx
+++ b/web/src/parts/checkpoints/Checkpoints.tsx
@@ -26,6 +26,9 @@ export default function Checkpoints() {
     if (!finalizedEpoch) return;
     return finalizedEpoch;
   }, [statusData]);
+  const latestRoot = useMemo(() => {
+    return statusData?.data?.finality?.finalized?.root;
+  }, [statusData]);
 
   if (isLoading)
     return (
@@ -48,6 +51,7 @@ export default function Checkpoints() {
       <CheckpointsTable
         slots={Object.values(data?.data?.slots ?? {})}
         latestEpoch={latestEpoch}
+        latestRoot={latestRoot}
         showCheckpoint={statusData?.data?.operating_mode === 'full'}
         onSlotClick={setSlot}
       />

--- a/web/src/parts/checkpoints/CheckpointsTable.tsx
+++ b/web/src/parts/checkpoints/CheckpointsTable.tsx
@@ -11,6 +11,7 @@ import { truncateHash } from '@utils';
 
 export default function CheckpointsTable(props: {
   latestEpoch?: string;
+  latestRoot?: string;
   slots: APIBeaconSlot[];
   onSlotClick?: (slot: APIBeaconSlot) => void;
   showCheckpoint?: boolean;
@@ -27,6 +28,12 @@ export default function CheckpointsTable(props: {
       );
     });
   }, [props.slots, search]);
+  const isServing = (slot: APIBeaconSlot) => {
+    if (props.latestRoot && slot.block_root) {
+      return slot.block_root === props.latestRoot;
+    }
+    return Boolean(props.latestEpoch && slot.epoch && slot.epoch === props.latestEpoch);
+  };
   const onClick = (slot: APIBeaconSlot) => {
     props.onSlotClick?.(slot);
   };
@@ -112,20 +119,17 @@ export default function CheckpointsTable(props: {
                     <tr key={slot.slot}>
                       <td className="hidden sm:table-cell sm:pl-6 sm:px-2 drop-shadow-lg whitespace-nowrap py-2 font-semibold text-sm sm:text-base text-gray-100">
                         {slot.epoch}
-                        {props.showCheckpoint &&
-                          props.latestEpoch &&
-                          slot.epoch &&
-                          slot.epoch === props.latestEpoch && (
-                            <img
-                              className="hidden sm:inline-block w-5 pl-2 -mt-1"
-                              src={FlagImage}
-                              alt="Latest checkpoint"
-                            />
-                          )}
+                        {props.showCheckpoint && isServing(slot) && (
+                          <img
+                            className="hidden sm:inline-block w-5 pl-2 -mt-1"
+                            src={FlagImage}
+                            alt="Latest checkpoint"
+                          />
+                        )}
                       </td>
                       <td className="whitespace-nowrap pl-2 sm:px-2 drop-shadow-lg sm:pl-0 py-2 font-semibold text-sm sm:text-base text-gray-100">
                         {slot.slot}
-                        {props.latestEpoch && slot.epoch && slot.epoch === props.latestEpoch && (
+                        {props.showCheckpoint && isServing(slot) && (
                           <img
                             className="sm:hidden w-5 inline-block pl-2 -mt-1"
                             src={FlagImage}


### PR DESCRIPTION
## Summary
The historical-checkpoints table flags the row currently being served. Previously it matched by epoch (`status.data.finality.finalized.epoch === slot.epoch`), which has two problems:

1. **Head/serving drift.** The slots list is built from `d.head` (majority-decided finality) while `status.data.finality` comes from `d.servingBundle` (last fully-downloaded bundle). When bundle downloads lag — e.g. short-lived devnets, kurtosis enclaves, or any transient fetch failure — `d.head` advances while `d.servingBundle` stays behind. Result: the slots list contains rows for epochs that aren't yet serving, so the flag appears on a non-top row or disappears until the bundle catches up.
2. **Epoch is ambiguous.** Two different block roots could share the same epoch across restarts/reorgs. Block root is the semantically correct identifier for "the bundle we're serving."

Switch to `slot.block_root === status.finality.finalized.root`, with a fallback to the old epoch comparison for rows whose `block_root` hasn't been populated yet.

## Repro
Spin up a kurtosis devnet with `SLOTS_PER_EPOCH=8`. While bundle downloads occasionally retry, the Checkpoints table's flag icon goes missing despite the upstream tab showing healthy finality.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] Manual: rebuild image, verify flag renders on the row matching `status.data.finality.finalized.root`, even when `d.head` is ahead of `d.servingBundle`

Related: #241 (underflow fix for `ListFinalizedSlots` that exposes this UI bug on short-lived chains).