### PR TITLE
fix(beacon): guard against nil finality fields and recover request panics

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
+  pull-requests: read
 jobs:
   golangci:
     name: lint
@@ -32,7 +32,7 @@ jobs:
           # args: --issues-exit-code=0
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+          only-new-issues: true
 
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.

--- a/pkg/beacon/checkpoints/majority/majority.go
+++ b/pkg/beacon/checkpoints/majority/majority.go
@@ -18,12 +18,28 @@ func New() *Decider {
 }
 
 func (m *Decider) Decide(checkpoints []*v1.Finality) (*v1.Finality, error) {
+	// Checkpoints with missing fields can't be keyed and don't count towards
+	// the majority threshold, matching how upstreams that fail to return
+	// finality at all are treated.
+	valid := make([]*v1.Finality, 0, len(checkpoints))
+
+	for _, checkpoint := range checkpoints {
+		if checkpoint == nil ||
+			checkpoint.Finalized == nil ||
+			checkpoint.Justified == nil ||
+			checkpoint.PreviousJustified == nil {
+			continue
+		}
+
+		valid = append(valid, checkpoint)
+	}
+
 	common := make(map[string]struct {
 		Finality *v1.Finality
 		Count    int
-	})
+	}, len(valid))
 
-	for _, checkpoint := range checkpoints {
+	for _, checkpoint := range valid {
 		key := eth.RootAsString(checkpoint.Finalized.Root) + "-" +
 			eth.RootAsString(checkpoint.Justified.Root) + "-" +
 			eth.RootAsString(checkpoint.PreviousJustified.Root)
@@ -46,7 +62,7 @@ func (m *Decider) Decide(checkpoints []*v1.Finality) (*v1.Finality, error) {
 	}
 
 	for _, v := range common {
-		if v.Count > len(checkpoints)/2 {
+		if v.Count > len(valid)/2 {
 			return v.Finality, nil
 		}
 	}

--- a/pkg/beacon/checkpoints/majority/majority_test.go
+++ b/pkg/beacon/checkpoints/majority/majority_test.go
@@ -88,3 +88,48 @@ func TestSplitMajority(t *testing.T) {
 		t.Errorf("Expected %v, got %v", ErrNoMajorityFound, err)
 	}
 }
+
+func TestNilFinalityIgnored(t *testing.T) {
+	payload := []*v1.Finality{
+		nil,
+		finalityA,
+		finalityA,
+		nil,
+	}
+
+	finality, err := majority.Decide(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if finality.Finalized.Root != finalityA.Finalized.Root {
+		t.Errorf("Expected %v, got %v", finalityA, finality)
+	}
+}
+
+func TestNilCheckpointFieldsIgnored(t *testing.T) {
+	payload := []*v1.Finality{
+		{Finalized: nil, Justified: checkpointB, PreviousJustified: checkpointB},
+		{Finalized: checkpointA, Justified: nil, PreviousJustified: checkpointB},
+		{Finalized: checkpointA, Justified: checkpointB, PreviousJustified: nil},
+		finalityA,
+	}
+
+	finality, err := majority.Decide(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if finality.Finalized.Root != finalityA.Finalized.Root {
+		t.Errorf("Expected %v, got %v", finalityA, finality)
+	}
+}
+
+func TestAllNilNoMajority(t *testing.T) {
+	payload := []*v1.Finality{nil, nil}
+
+	_, err := majority.Decide(payload)
+	if err != ErrNoMajorityFound {
+		t.Errorf("Expected %v, got %v", ErrNoMajorityFound, err)
+	}
+}

--- a/pkg/beacon/default.go
+++ b/pkg/beacon/default.go
@@ -485,6 +485,15 @@ func (d *Default) checkFinality(ctx context.Context) error {
 			continue
 		}
 
+		if finality == nil ||
+			finality.Finalized == nil ||
+			finality.Justified == nil ||
+			finality.PreviousJustified == nil {
+			d.log.Infof("Node %s returned incomplete finality", node.Config.Name)
+
+			continue
+		}
+
 		aggFinality = append(aggFinality, finality)
 	}
 

--- a/pkg/checkpointz/checkpointz.go
+++ b/pkg/checkpointz/checkpointz.go
@@ -60,6 +60,17 @@ func (s *Server) Start(ctx context.Context) error {
 
 	router := httprouter.New()
 
+	router.PanicHandler = func(w http.ResponseWriter, r *http.Request, rcv any) {
+		s.log.
+			WithField("panic", rcv).
+			WithField("path", r.URL.Path).
+			Error("Recovered from panic while handling request")
+
+		if err := api.WriteErrorResponse(w, "internal server error", http.StatusInternalServerError); err != nil {
+			s.log.WithError(err).Error("Failed to write panic error response")
+		}
+	}
+
 	if err := s.http.Register(ctx, router); err != nil {
 		return err
 	}


### PR DESCRIPTION
If an upstream returned a `Finality` with a nil `Finalized`, `Justified`, or `PreviousJustified`, the majority decider dereferenced it directly and panicked. Because this runs in the background polling goroutine rather than an HTTP handler, that panic took down the process.

The decider now skips finality entries with nil fields (they don't count toward the majority threshold), `checkFinality` filters them before aggregating, and the HTTP router gets a `PanicHandler` so a panic on the request path returns a 500 instead of crashing.
