### PR TITLE
chore(docker): run containers as non-root and pin base images by digest

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
+  pull-requests: read
 jobs:
   golangci:
     name: lint
@@ -32,7 +32,7 @@ jobs:
           # args: --issues-exit-code=0
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+          only-new-issues: true
 
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
-FROM golang:1.26 AS builder
+FROM golang:1.26-bookworm@sha256:13e7249b4618c115a175ea2627213131855233ecf465328cac30a0f754beb985 AS builder
 WORKDIR /src
 COPY go.sum go.mod ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o /bin/app .
 
-FROM ubuntu:latest
+FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --uid 10001 --no-create-home --user-group checkpointz
 COPY --from=builder /bin/app /checkpointz
+USER checkpointz
 EXPOSE 5555
 ENTRYPOINT ["/checkpointz"]

--- a/goreleaser-debian.Dockerfile
+++ b/goreleaser-debian.Dockerfile
@@ -1,10 +1,12 @@
-FROM debian:latest
+FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf87857c4b8188404716
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \
   curl \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --uid 10001 --no-create-home --user-group checkpointz
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/checkpointz* /checkpointz
+USER checkpointz
 ENTRYPOINT ["/checkpointz"]

--- a/goreleaser-scratch.Dockerfile
+++ b/goreleaser-scratch.Dockerfile
@@ -1,4 +1,5 @@
-FROM gcr.io/distroless/static-debian11:latest
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/checkpointz* /checkpointz
+USER nonroot
 ENTRYPOINT ["/checkpointz"]


### PR DESCRIPTION
None of the container images set a `USER`, so they ran as root, and the distroless image used `static-debian11:latest` (which also defaults to root). All base images used floating `:latest` tags.

This switches the scratch image to `static-debian12:nonroot`, adds a dedicated non-root `checkpointz` user (uid 10001) to the debian and ubuntu images, and pins every base image by digest. The listen and metrics ports (5555/9090) are unprivileged, so dropping root needs no other changes.
