### PR TITLE
fix(eth): reject negative slot identifiers

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
+  pull-requests: read
 jobs:
   golangci:
     name: lint
@@ -32,7 +32,7 @@ jobs:
           # args: --issues-exit-code=0
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+          only-new-issues: true
 
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.

--- a/pkg/service/eth/block_id.go
+++ b/pkg/service/eth/block_id.go
@@ -68,7 +68,7 @@ func NewBlockIdentifier(id string) (BlockIdentifier, error) {
 		return newBlockIdentifier(BlockIDRoot, id), nil
 	}
 
-	if _, err := strconv.ParseInt(id, 10, 64); err == nil {
+	if _, err := strconv.ParseUint(id, 10, 64); err == nil {
 		return newBlockIdentifier(BlockIDSlot, id), nil
 	}
 
@@ -83,12 +83,12 @@ func newBlockIdentifier(id BlockIDType, value string) BlockIdentifier {
 }
 
 func NewSlotFromString(id string) (phase0.Slot, error) {
-	slot, err := strconv.ParseInt(id, 10, 64)
+	slot, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
 		return 0, err
 	}
 
-	return phase0.Slot(uint64(slot)), nil //nolint:gosec // slot parsed from string is validated
+	return phase0.Slot(slot), nil
 }
 
 func NewRootFromString(id string) (phase0.Root, error) {

--- a/pkg/service/eth/block_id_test.go
+++ b/pkg/service/eth/block_id_test.go
@@ -30,3 +30,30 @@ func TestBlockIDMapping(t *testing.T) {
 		})
 	}
 }
+
+func TestBlockIDRejectsNegativeSlot(t *testing.T) {
+	t.Parallel()
+
+	for _, id := range []string{"-1", "-100"} {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := NewBlockIdentifier(id)
+			if err == nil {
+				t.Errorf("Expected error for %q, got type %d", id, parsed.Type())
+			}
+
+			if parsed.Type() != BlockIDInvalid {
+				t.Errorf("Expected BlockIDInvalid for %q, got %d", id, parsed.Type())
+			}
+		})
+	}
+}
+
+func TestNewSlotFromStringRejectsNegative(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewSlotFromString("-1"); err == nil {
+		t.Error("Expected error for negative slot, got nil")
+	}
+}

--- a/pkg/service/eth/state_id.go
+++ b/pkg/service/eth/state_id.go
@@ -66,7 +66,7 @@ func NewStateIdentifier(id string) (StateIdentifier, error) {
 		return newStateIdentifier(StateIDRoot, id), nil
 	}
 
-	if _, err := strconv.ParseInt(id, 10, 64); err == nil {
+	if _, err := strconv.ParseUint(id, 10, 64); err == nil {
 		return newStateIdentifier(StateIDSlot, id), nil
 	}
 


### PR DESCRIPTION
Slot block and state identifiers were parsed with `ParseInt`, so a negative value like `-1` was accepted as a valid slot and then wrapped to a huge `uint64`. It only ever produced a store miss, but the request was treated as well-formed rather than rejected.

Slot parsing now uses `ParseUint`, so negative identifiers are classified as invalid and return a 400. This also removes the now-unnecessary gosec suppression on the slot conversion.
