### PR TITLE
fix(beacon): verify fetched beacon state hashes to the block state root

### DIFF
--- a/pkg/beacon/download.go
+++ b/pkg/beacon/download.go
@@ -389,6 +389,20 @@ func (d *Default) downloadAndStoreBeaconState(ctx context.Context, stateRoot pha
 		return errors.New("beacon state is nil")
 	}
 
+	// Verify that the state the node returned for this slot actually hashes to the
+	// state root committed to in the block. Nodes that are behind can otherwise
+	// respond to a by-slot state request with a state from a different chain (e.g.
+	// their stale head dialed forward through empty slots), which would then be
+	// stored and served under a state root it does not match.
+	computedRoot, err := d.sszEncoder.GetStateRoot(beaconState)
+	if err != nil {
+		return fmt.Errorf("failed to compute state root: %w", err)
+	}
+
+	if computedRoot != stateRoot {
+		return fmt.Errorf("beacon state root mismatch: node %s returned a state for slot %d with root %#x, expected %#x", node.Config.Name, slot, computedRoot, stateRoot)
+	}
+
 	expiresAt := time.Now().Add(FinalityHaltedServingPeriod)
 	if slot == phase0.Slot(0) {
 		expiresAt = time.Now().Add(999999 * time.Hour)


### PR DESCRIPTION
## Problem

`downloadAndStoreBeaconState` fetches the finalized state **by slot** from a single upstream and stores whatever bytes come back under the block's `state_root`, without ever verifying them. The state is then served verbatim at `/eth/v2/debug/beacon/states/finalized`.

A beacon node that has fallen behind can answer a by-slot state request with a state from a different chain view instead of erroring — lodestar (and lighthouse, in a different way) serve their **stale head state dialed forward through empty slots** for slots beyond their head. Checkpointz caches that fabricated state under the real `block.state_root` and serves it; checkpoint-syncing clients then fail their `hash_tree_root(state) == block.state_root` anchor check.

## Observed on glamsterdam-devnet-7

- `lodestar-geth-1`'s head froze at slot 56351 while checkpointz still listed it `healthy: true`.
- Asked for the state at the network's finalized checkpoint slot 71391, it returned a state with `latest_block_header.slot = 56351` dialed forward ~15k empty slots, HTR `0xcb39fc23…` — matching nothing on the canonical chain (expected `0x2d414744…`).
- The serving path's `PastFinalizedCheckpoint` node filter usually keeps such nodes out, but it filters on *claimed finality*, not head — finality stalls, optimistic finality claims, or a node freezing near a serving flip let a fabricating upstream through, and nothing downstream catches it.

## Fix

Compute the hash tree root of the fetched state (existing `sszEncoder.GetStateRoot`) and reject the bundle if it doesn't match the state root committed to in the block. The bad upstream's bundle fails, and the serving loop retries with another node.

Cost: one state HTR per bundle download (once per serving-checkpoint flip / genesis fetch) — ~1s for a 73 MB gloas state.

## Testing

- `go build ./...` / `go test ./...` green.
- Patched binary run against three glamsterdam-devnet-7 upstreams: downloaded, verified and served the epoch-2236 bundle (no false positive on a real 73 MB / 503k-validator gloas state), served bytes byte-identical to the upstream's by-root copy.

The same code exists on `master`; happy to open a port there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017K6pyDaSgX2FcLtQ1qQ8Vu